### PR TITLE
Updates documentation about PHP 7 configuration

### DIFF
--- a/docs/other/php-7.md
+++ b/docs/other/php-7.md
@@ -22,6 +22,7 @@ php_packages:
   - php7.0-opcache
 php_mysql_package: php7.0-mysql
 php_fpm_daemon: php7.0-fpm
+php_fpm_pool_conf_path: "/etc/php/7.0/fpm/pool.d/www.conf"
 ```
 
 Also, comment out `xhprof`, `xdebug`, `redis` and `memcached` from the `installed_extras` list, as these extensions are not yet supported for PHP 7 (as of late 2015).


### PR DESCRIPTION
Hey, i was just trying to follow http://docs.drupalvm.com/en/latest/other/php-7/ and found that no matter what during initial provision i am getting errors like:

```
TASK [geerlingguy.php : Configure php-fpm pool (if enabled).] ******************
failed: [pm8] => (item={u'regexp': u'^listen.?=.+$', u'line': u'listen = 127.0.0.1:9000'}) => {"failed": true, "item": {"line": "listen = 127.0.0.1:9000", "regexp": "^listen.?=.+$"}, "msg": "Destination /etc/php5/fpm/pool.d/www.conf does not exist !", "rc": 257}
failed: [pm8] => (item={u'regexp': u'^listen\\.allowed_clients.?=.+$', u'line': u'listen.allowed_clients = 127.0.0.1'}) => {"failed": true, "item": {"line": "listen.allowed_clients = 127.0.0.1", "regexp": "^listen\\.allowed_clients.?=.+$"}, "msg": "Destination /etc/php5/fpm/pool.d/www.conf does not exist !", "rc": 257}
failed: [pm8] => (item={u'regexp': u'^pm\\.max_children.?=.+$', u'line': u'pm.max_children = 50'}) => {"failed": true, "item": {"line": "pm.max_children = 50", "regexp": "^pm\\.max_children.?=.+$"}, "msg": "Destination /etc/php5/fpm/pool.d/www.conf does not exist !", "rc": 257}
failed: [pm8] => (item={u'regexp': u'^pm\\.start_servers.?=.+$', u'line': u'pm.start_servers = 5'}) => {"failed": true, "item": {"line": "pm.start_servers = 5", "regexp": "^pm\\.start_servers.?=.+$"}, "msg": "Destination /etc/php5/fpm/pool.d/www.conf does not exist !", "rc": 257}
failed: [pm8] => (item={u'regexp': u'^pm\\.min_spare_servers.?=.+$', u'line': u'pm.min_spare_servers = 5'}) => {"failed": true, "item": {"line": "pm.min_spare_servers = 5", "regexp": "^pm\\.min_spare_servers.?=.+$"}, "msg": "Destination /etc/php5/fpm/pool.d/www.conf does not exist !", "rc": 257}
failed: [pm8] => (item={u'regexp': u'^pm\\.max_spare_servers.?=.+$', u'line': u'pm.max_spare_servers = 5'}) => {"failed": true, "item": {"line": "pm.max_spare_servers = 5", "regexp": "^pm\\.max_spare_servers.?=.+$"}, "msg": "Destination /etc/php5/fpm/pool.d/www.conf does not exist !", "rc": 257}
```

So apparently ansible were trying to write to PHP 5 fpm pool configuration file instead of PHP 7. Adding the line `hp_fpm_pool_conf_path: "/etc/php/7.0/fpm/pool.d/www.conf"` should fix this.